### PR TITLE
Add Appian SAIL user management interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
 # sail-codex-test
+
+Este repositorio contiene ejemplos sencillos de c\u00f3digo SAIL para Appian. Se incluyen dos interfaces que comparten la misma lista de usuarios:
+
+- **add_user_interface.sail**: formulario para agregar un nuevo usuario.
+- **view_users_interface.sail**: listado de usuarios registrados.
+
+La lista inicial de datos se define en **rules/initial_users.sail**. Ambos formularios deben recibir como par\u00e1metro la misma variable de usuarios (por ejemplo, una variable de proceso) para trabajar de forma conjunta dentro de una aplicaci\u00f3n o sitio.
+
+## Estructura
+
+```
+appian/
+  interfaces/
+    add_user_interface.sail
+    view_users_interface.sail
+  rules/
+    initial_users.sail
+```
+
+Estos archivos pueden importarse en Appian y vincularse a un Site para permitir la gesti\u00f3n y visualizaci\u00f3n de usuarios.

--- a/appian/interfaces/add_user_interface.sail
+++ b/appian/interfaces/add_user_interface.sail
@@ -1,0 +1,37 @@
+/*
+ * Interfaz de SAIL para agregar usuarios a la misma aplicaci\u00f3n.
+ * Espera como par\u00e1metro una lista de usuarios (ri!users) que debe
+ * ser compartida con la interfaz de consulta.
+ */
+=a!localVariables(
+  local!nuevoUsuario: { nombre: "", correo: "" },
+  a!formLayout(
+    label: "Agregar Nuevo Usuario",
+    contents: {
+      a!textField(
+        label: "Nombre de usuario",
+        value: local!nuevoUsuario.nombre,
+        saveInto: local!nuevoUsuario.nombre,
+        required: true
+      ),
+      a!textField(
+        label: "Correo electr\u00f3nico",
+        value: local!nuevoUsuario.correo,
+        saveInto: local!nuevoUsuario.correo,
+        required: true
+      ),
+      a!buttonArrayLayout(
+        buttons: {
+          a!buttonWidgetSubmit(
+            label: "Guardar",
+            saveInto: {
+              a!save(ri!users, append(ri!users, local!nuevoUsuario)),
+              a!save(local!nuevoUsuario, { nombre: "", correo: "" })
+            }
+          )
+        }
+      )
+    }
+  )
+)
+

--- a/appian/interfaces/view_users_interface.sail
+++ b/appian/interfaces/view_users_interface.sail
@@ -1,0 +1,24 @@
+/*
+ * Interfaz de SAIL para mostrar el listado de usuarios registrados.
+ * Espera como par\u00e1metro la misma lista de usuarios que usa la
+ * interfaz de agregaci\u00f3n.
+ */
+=a!formLayout(
+  label: "Usuarios Registrados",
+  contents: {
+    a!gridField(
+      data: ri!users,
+      columns: {
+        a!gridTextColumn(
+          label: "Nombre",
+          field: "nombre"
+        ),
+        a!gridTextColumn(
+          label: "Correo",
+          field: "correo"
+        )
+      }
+    )
+  }
+)
+

--- a/appian/rules/initial_users.sail
+++ b/appian/rules/initial_users.sail
@@ -1,0 +1,10 @@
+/*
+ * Regla de expresi\u00f3n que devuelve la lista inicial de usuarios
+ * utilizada por ambas interfaces. En un entorno real podr\u00eda ser una
+ * consulta a una entidad de datos.
+ */
+{
+  { nombre: "ana", correo: "ana@example.com" },
+  { nombre: "luis", correo: "luis@example.com" }
+}
+


### PR DESCRIPTION
## Summary
- create an example Appian project
- add an interface for adding users
- add an interface for displaying users
- provide an expression rule with initial user data
- document repository structure

## Testing
- `pytest -q`
- `npm test` *(fails: ENOENT could not read package.json)*
- `make test` *(fails: No rule to make target `test`)*

------
https://chatgpt.com/codex/tasks/task_e_6843292a51b88324a27690e0058f0b55